### PR TITLE
Fix for command pdf bibtex fileending

### DIFF
--- a/src/main/java/textools/commands/Pdf.java
+++ b/src/main/java/textools/commands/Pdf.java
@@ -39,6 +39,9 @@ public class Pdf implements Command {
     }
 
     private void bibtex(String mainLatexFile) {
+    	if(mainLatexFile.contains(".tex")){
+    		mainLatexFile = mainLatexFile.substring(0,mainLatexFile.lastIndexOf(".tex"));
+    	}
         executeWithLog("bibtex " + mainLatexFile, TEXTOOLS_PDF_LOG);
     }
 


### PR DESCRIPTION
Es wird vor Ausführung des bibtex-Befehls überprüft, ob die Dateeiendung .tex vorliegt und dann ggf. entfernt.
