### PR TITLE
Fix #9 Check for author field and fix #11 only abbreviate authors >= 3

### DIFF
--- a/src/main/java/textools/commands/MinifyBibtexAuthors.java
+++ b/src/main/java/textools/commands/MinifyBibtexAuthors.java
@@ -42,14 +42,19 @@ public class MinifyBibtexAuthors implements Command {
     public void minifyDatabase(BibTeXDatabase database) {
         for (BibTeXEntry entry : database.getEntries().values()) {
 
-            String author = entry.getField(new Key("author")).toUserString();
-            String abbreviatedAuthor = abbreviateAuthor(author);
+            Value author = entry.getField(new Key("author"));
+			
+			if(author != null) {
+				String abbreviatedAuthor = abbreviateAuthor(author.toUserString());
 
-            if (!author.equals(abbreviatedAuthor)) {
-                //entry.removeField(new Key("author"));
-                System.out.println("\tMinifying " + entry.getKey() + ": abbreviating author to " + abbreviatedAuthor);
-                entry.addField(new Key("author"), new StringValue(abbreviatedAuthor, StringValue.Style.BRACED));
-            }
+				if (!author.equals(abbreviatedAuthor)) {
+					//entry.removeField(new Key("author"));
+					System.out.println("\tMinifying " + entry.getKey() + ": abbreviating author to " + abbreviatedAuthor);
+					entry.addField(new Key("author"), new StringValue(abbreviatedAuthor, StringValue.Style.BRACED));
+				}
+			} else {
+				System.out.println("\tSkipping " + entry.getKey() + ": missing author field");
+			}
         }
     }
 

--- a/src/main/java/textools/commands/MinifyBibtexAuthors.java
+++ b/src/main/java/textools/commands/MinifyBibtexAuthors.java
@@ -76,7 +76,7 @@ public class MinifyBibtexAuthors implements Command {
         }
 
         // already abbreviated
-        if ("others".equals(authors[authors.length - 1]) && authors.length == 3) {
+        if ("others".equals(authors[authors.length - 1]) && authors.length == 2) {
             return author;
         }
 

--- a/src/test/java/textools/commands/MinifyBibtexAuthorsTests.java
+++ b/src/test/java/textools/commands/MinifyBibtexAuthorsTests.java
@@ -9,8 +9,9 @@ public class MinifyBibtexAuthorsTests {
     public void testMinifyAuthorNames() {
         Assert.assertEquals("Simon Harrer", new MinifyBibtexAuthors().abbreviateAuthor("Simon Harrer"));
         Assert.assertEquals("Simon Harrer and others", new MinifyBibtexAuthors().abbreviateAuthor("Simon Harrer and others"));
-        Assert.assertEquals("Simon Harrer and others", new MinifyBibtexAuthors().abbreviateAuthor("Simon Harrer and Jörg Lenhard"));
+        Assert.assertEquals("Simon Harrer and Jörg Lenhard", new MinifyBibtexAuthors().abbreviateAuthor("Simon Harrer and Jörg Lenhard"));
         Assert.assertEquals("Simon Harrer and others", new MinifyBibtexAuthors().abbreviateAuthor("Simon Harrer and Jörg Lenhard and Guido Wirtz"));
+        Assert.assertEquals("Simon Harrer and others", new MinifyBibtexAuthors().abbreviateAuthor("Simon Harrer and Jörg Lenhard and Guido Wirtz and others"));
     }
 
 }


### PR DESCRIPTION
You may review this and skip the three or more thing. I know you wanted to minimize authors as much as you can. I think we should still keep the IEEE style and only abbreviate 3 or more.