### PR TITLE
Made the `space before label' rule more restrictive

### DIFF
--- a/src/main/java/textools/commands/ValidateLatex.java
+++ b/src/main/java/textools/commands/ValidateLatex.java
@@ -41,7 +41,7 @@ public class ValidateLatex implements Command {
     private static Map<String, String> getRules() {
         Map<String, String> rules = new HashMap<>();
         rules.put("^\\\\footnote(\\{|\\[)", "line starts with footnote");
-        rules.put(" \\\\label", "space in front of label");
+        rules.put(" \\\\label\\{", "space in front of label");
         rules.put("\\\\caption\\{.*\\\\ac\\{", "acronym in caption");
         rules.put(" \\\\footnote", "space in front of footnote");
         rules.put("[^~]\\\\ref", "use '~\\ref' to prevent bad line breaks");

--- a/src/test/resources/errors.tex
+++ b/src/test/resources/errors.tex
@@ -2,7 +2,7 @@
 \footnote{asdf}
  \ref
  \footnote
- \label
+ \label{somelabel}
 .~\cite is wrong but et al.~\cite is ok
 In~\cite
 figure~\ref

--- a/src/test/resources/errors.tex
+++ b/src/test/resources/errors.tex
@@ -27,3 +27,4 @@ whatever,, asdfasdf
 In order to do something
 behaviour
 all of the
+\caption{\ac{some}}


### PR DESCRIPTION
Hi Simon,
the mentioned rule was a bit too unspecific, resulting if false positives if one used a space before commands that start with \label, e.g., \labelsep etc.

I fixed that, and also a failing test. (:

Cheers,
Linus