### PR TITLE
Remove the 'while rule'

### DIFF
--- a/src/main/java/textools/commands/ValidateLatex.java
+++ b/src/main/java/textools/commands/ValidateLatex.java
@@ -48,7 +48,6 @@ public class ValidateLatex implements Command {
         rules.put("(?<!et( |~)al)\\.~?\\\\cite", "use cite before the dot"); // use negative lookbehind in regex
         rules.put("[^~\\{\\}]\\\\cite[^tp]", "use '~\\cite' to prevent bad line breaks");
         rules.put("But ", "use 'A few words, however, ...' instead");
-        rules.put("(While|, while) ", "use 'Although' instead");
         rules.put("''\\.", "move . into quotes");
         rules.put("[Bb]ecause of this", "use hence instead of because of this");
         rules.put("(Java|activiti|camunda~BPM|ODE) \\d+", "Instead of Java 8, use Java~8");

--- a/src/test/resources/errors.tex
+++ b/src/test/resources/errors.tex
@@ -30,8 +30,6 @@ In order to do something
 behaviour
 all of the things
 \caption{\ac{some}}
-While something
-asdfasd, while asdfasdf
 But this is important
 ``asdfasdf''.
 Java 8


### PR DESCRIPTION
In my opinion, 'while' cannot be interchanged with 'although' in all cases. This leads to frequent false positives, thus, I'd recommend to entirely remove this rule.